### PR TITLE
fix: update inkplate library reference and fix drawBitmapFromSd case change

### DIFF
--- a/lib/dashboard/Dashboard.cpp
+++ b/lib/dashboard/Dashboard.cpp
@@ -126,7 +126,7 @@ void Dashboard::drawConditionIcon(String &condition, int size, int x, int y)
 
   Serial.println(filenameCharArray);
 
-  display.drawBitmapFromSD(filenameCharArray, x, y);
+  display.drawBitmapFromSd(filenameCharArray, x, y);
 }
 
 void Dashboard::drawWeather()

--- a/lib/image-screen/ImageScreen.cpp
+++ b/lib/image-screen/ImageScreen.cpp
@@ -1,6 +1,6 @@
 #include "ImageScreen.h"
 
 void ImageScreen::draw() {
-  display.drawBitmapFromSD("image1.bmp", 0, 0);
+  display.drawBitmapFromSd("image1.bmp", 0, 0);
   display.display();
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ build_flags =
 board_build.partitions = no_ota.csv
 
 lib_deps=
-   https://github.com/e-radionicacom/Inkplate-6-Arduino-library.git#dev
+   https://github.com/e-radionicacom/Inkplate-Arduino-library.git
    https://github.com/e-radionicacom/Inkplate-6-SDFat-Arduino-Library.git
    adafruit/Adafruit Unified Sensor @ ^1.1.4
    bblanchon/ArduinoJson @ ^6.16.1


### PR DESCRIPTION
Existing reference to E-radionica's GitHub repo for Inkplate Arduino library is now a dead link; update this to the current repo name.

At some point drawBitmapFromSD was renamed to drawBitmapFromSd which broke compile, fix both references.

Build-tested.